### PR TITLE
Fallback to npm when yarn is unavailable

### DIFF
--- a/run.js
+++ b/run.js
@@ -11,6 +11,16 @@ if (fs.existsSync(packageJsonPath)) {
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
 
   if (packageJson.scripts && packageJson.scripts.postinstall) {
-    exec('yarn run postinstall', {cwd: appPath})
+    const pkgManager = shouldUseYarn() ? 'yarn' : 'npm';
+    exec(`${pkgManager} run postinstall`, {cwd: appPath})
+  }
+}
+
+function shouldUseYarn() {
+  try {
+    exec('yarnpkg --version', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
   }
 }


### PR DESCRIPTION
This change ensures that projects with `postinstall-postinstall` still work in `npm` only environment.

`shouldUseYarn` is extracted from https://github.com/facebook/create-react-app/blob/master/packages/create-react-app/createReactApp.js#L333-L340

Fixes #5