### PR TITLE
Specify stdio option when invoking package manager

### DIFF
--- a/run.js
+++ b/run.js
@@ -12,7 +12,7 @@ if (fs.existsSync(packageJsonPath)) {
 
   if (packageJson.scripts && packageJson.scripts.postinstall) {
     const pkgManager = shouldUseYarn() ? 'yarn' : 'npm';
-    exec(`${pkgManager} run postinstall`, {cwd: appPath})
+    exec(`${pkgManager} run postinstall`, {cwd: appPath, stdio: 'ignore'})
   }
 }
 


### PR DESCRIPTION
When this option isn't specified, `yarn` errors out (`npm` does not do this). This error only seems to occur for some people and not all. I haven't been able to narrow down the conditions that induce the error, it suddenly started happening to me today.

## Sample script: 
```js
const exec = require('child_process').execSync;

exec('yarn run postinstall', {});
```

## Output:

```
node test.js || echo "Exit code: $?"
child_process.js:866
    throw err;
    ^

Error: Command failed: yarn run postinstall
    at checkExecSyncError (child_process.js:790:11)
    at execSync (child_process.js:863:15)
    at Object.<anonymous> (/tmp/test/test.js:3:1)
    at Module._compile (internal/modules/cjs/loader.js:1085:14)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
    at Module.load (internal/modules/cjs/loader.js:950:32)
    at Function.Module._load (internal/modules/cjs/loader.js:790:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47 {
  status: 1,
  signal: null,
  output: [ null, Buffer(0) [Uint8Array] [], Buffer(0) [Uint8Array] [] ],
  pid: 12204,
  stdout: Buffer(0) [Uint8Array] [],
  stderr: Buffer(0) [Uint8Array] []
}
Exit code: 1
```

## Fixed script:

```js
const exec = require('child_process').execSync;

exec('yarn run postinstall', { stdio: 'ignore' });
```

## Output: 

```
node test.js && echo "Exit code: $?"
Exit code: 0
```

### Node version
```
$ node -v
v14.18.3
```
### Yarn version
```
$ yarn -v
1.22.17
```

Fixes https://github.com/ds300/postinstall-postinstall/issues/7